### PR TITLE
Adding semicolon rules to eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
         "no-useless-backreference": "error",
         "require-atomic-updates": "error",
         "eqeqeq": "error",
-        "semi": ["error", "always", { "omitLastInOneLineBlock": true, }],
+        "semi": ["error", "always", { "omitLastInOneLineBlock": false, }],
         "semi-style": ["error", "last"],
         "no-extra-semi": ["error"],
         "semi-spacing": ["error", { "before": false, "after": true }],

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ module.exports = {
         "no-useless-backreference": "error",
         "require-atomic-updates": "error",
         "eqeqeq": "error",
+        "semi": ["error", "always", { "omitLastInOneLineBlock": false, }],
+        "semi-style": ["error", "last"],
+        "no-extra-semi": ["error"],
+        "semi-spacing": ["error", { "before": false, "after": true }],
 
 
         //

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
         "no-useless-backreference": "error",
         "require-atomic-updates": "error",
         "eqeqeq": "error",
-        "semi": ["error", "always", { "omitLastInOneLineBlock": false, }],
+        "semi": ["error", "always", { "omitLastInOneLineBlock": true, }],
         "semi-style": ["error", "last"],
         "no-extra-semi": ["error"],
         "semi-spacing": ["error", { "before": false, "after": true }],


### PR DESCRIPTION
Adding following semicolon rules:

`"semi": ["error", "always", { "omitLastInOneLineBlock": false, }],`
- Missing semicolon will result in an eslint error.
- Semicolons are optional in one line blocks like `if (foo) { bar(); baz() }`.

` "semi-style": ["error", "last"]`
- Semicolons must be on the end of the line. You cannot put them on the next line.

`"no-extra-semi": ["error"]`
- 2 or more semicolons in a row are not allowed.

`"semi-spacing": ["error", { "before": false, "after": true }]`
- Spacing before the semicolon is not allowed.
- Spacing after the semicolon is allowed.